### PR TITLE
Impossibilité d'avoir un environnement stable sur MAC

### DIFF
--- a/Sudoku.Backtracking/Resources/Backtracking.py
+++ b/Sudoku.Backtracking/Resources/Backtracking.py
@@ -16,6 +16,7 @@ def is_valid(grid, row, col, num):
         for c in range(start_col, start_col + 3):
             if grid[r, c] == num:
                 return False
+            
     return True
 
 def solve_sudoku(grid, row=0, col=0):


### PR DESCRIPTION
Re bonjour Monsieur BOIGE,

Il nous est toujours impossible d'exécuter le solver1simplepython1million. L'erreur indique que pip est correctement configuré pour Python 3.10, mais que l'exécution de pip3 ne fonctionne pas en raison d'un lien symbolique manquant ou d'un chemin incorrect. À noter que votre solverPython fonctionne lorsqu'on l'exécute, mais que le SudokuZ3Solver, lui, ne fonctionne pas et renvoie la même erreur que pour solver1simplepython1million.

Merci pour votre aide, 

Cordialement.